### PR TITLE
BTA-318: Hide already enroled oils

### DIFF
--- a/app/controllers/actions/AuthAction.scala
+++ b/app/controllers/actions/AuthAction.scala
@@ -26,6 +26,8 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.Retrievals
 import uk.gov.hmrc.http.{HeaderCarrier, UnauthorizedException}
 import uk.gov.hmrc.play.HeaderCarrierConverter
+import uk.gov.hmrc.auth.core.retrieve.~
+
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -35,9 +37,10 @@ class AuthActionImpl @Inject()(override val authConnector: AuthConnector, config
   override def invokeBlock[A](request: Request[A], block: (AuthenticatedRequest[A]) => Future[Result]): Future[Result] = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
 
-    authorised().retrieve(Retrievals.externalId) {
-      _.map {
-        externalId => block(AuthenticatedRequest(request, externalId))
+    authorised().retrieve(Retrievals.externalId and Retrievals.allEnrolments) {
+      case externalId ~ enrolments =>
+      externalId.map {
+        externalId => block(AuthenticatedRequest(request, externalId, enrolments))
       }.getOrElse(throw new UnauthorizedException("Unable to retrieve external Id"))
     } recover {
       case ex: NoActiveSession =>

--- a/app/models/SelectAnOilService.scala
+++ b/app/models/SelectAnOilService.scala
@@ -18,7 +18,9 @@ package models
 
 import utils.{Enumerable, RadioOption, WithName}
 
-sealed trait SelectAnOilService
+sealed trait SelectAnOilService {
+  val toRadioOption = RadioOption("selectAnOilService", this.toString)
+}
 
 object SelectAnOilService {
 
@@ -31,8 +33,7 @@ object SelectAnOilService {
   )
 
   val options: Set[RadioOption] = values.map {
-    value =>
-      RadioOption("selectAnOilService", value.toString)
+    _.toRadioOption
   }
 
   implicit val enumerable: Enumerable[SelectAnOilService] =

--- a/app/models/requests/AuthenticatedRequest.scala
+++ b/app/models/requests/AuthenticatedRequest.scala
@@ -17,5 +17,6 @@
 package models.requests
 
 import play.api.mvc.{Request, WrappedRequest}
+import uk.gov.hmrc.auth.core.Enrolments
 
-case class AuthenticatedRequest[A](request: Request[A], externalId: String) extends WrappedRequest[A](request)
+case class AuthenticatedRequest[A](request: Request[A], externalId: String, enrolments: Enrolments) extends WrappedRequest[A](request)

--- a/app/models/requests/ServiceInfoRequest.scala
+++ b/app/models/requests/ServiceInfoRequest.scala
@@ -19,5 +19,5 @@ package models.requests
 import play.api.mvc.{Request, WrappedRequest}
 import play.twirl.api.Html
 
-case class ServiceInfoRequest[A](request: Request[A], serviceInfoContent: Html) extends WrappedRequest[A](request)
+case class ServiceInfoRequest[A](request: AuthenticatedRequest[A], serviceInfoContent: Html) extends WrappedRequest[A](request)
 

--- a/app/views/selectAnOilService.scala.html
+++ b/app/views/selectAnOilService.scala.html
@@ -18,8 +18,9 @@
 @import uk.gov.hmrc.play.views.html._
 @import controllers.routes._
 @import models.SelectAnOilService
+@import utils.RadioOption
 
-@(appConfig: FrontendAppConfig, form: Form[_])(serviceInfoContent: Html)(implicit request: Request[_], messages: Messages)
+@(appConfig: FrontendAppConfig, form: Form[_], options: Seq[RadioOption])(serviceInfoContent: Html)(implicit request: Request[_], messages: Messages)
 
 @main_template(
     title = messages("selectAnOilService.title"),
@@ -37,7 +38,7 @@
             field = form("value"),
             legend = messages("selectAnOilService.heading"),
             legendClass = Some("visually-hidden"),
-            inputs = SelectAnOilService.options.toSeq,
+            inputs = options,
             trackGa = true,
             gaEvent = "AddOilTax"
         )

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -3,11 +3,11 @@ import sbt.Tests.{Group, SubProcess}
 import sbt._
 import scoverage.ScoverageKeys
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
-
 import com.typesafe.sbt.web.Import._
 import net.ground5hark.sbt.concat.Import._
 import com.typesafe.sbt.uglify.Import._
 import com.typesafe.sbt.digest.Import._
+import play.sbt.routes.RoutesKeys
 
 trait MicroService {
 

--- a/test/controllers/actions/DataRetrievalActionSpec.scala
+++ b/test/controllers/actions/DataRetrievalActionSpec.scala
@@ -22,6 +22,7 @@ import models.requests.{AuthenticatedRequest, OptionalDataRequest}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
+import uk.gov.hmrc.auth.core.Enrolments
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -40,7 +41,7 @@ class DataRetrievalActionSpec extends SpecBase with MockitoSugar with ScalaFutur
         when(dataCacheConnector.fetch("id")) thenReturn Future(None)
         val action = new Harness(dataCacheConnector)
 
-        val futureResult = action.callTransform(new AuthenticatedRequest(fakeRequest, "id"))
+        val futureResult = action.callTransform(new AuthenticatedRequest(fakeRequest, "id", Enrolments(Set())))
 
         whenReady(futureResult) { result =>
           result.userAnswers.isEmpty mustBe true
@@ -54,7 +55,7 @@ class DataRetrievalActionSpec extends SpecBase with MockitoSugar with ScalaFutur
         when(dataCacheConnector.fetch("id")) thenReturn Future(Some(new CacheMap("id", Map())))
         val action = new Harness(dataCacheConnector)
 
-        val futureResult = action.callTransform(new AuthenticatedRequest(fakeRequest, "id"))
+        val futureResult = action.callTransform(new AuthenticatedRequest(fakeRequest, "id", Enrolments(Set())))
 
         whenReady(futureResult) { result =>
           result.userAnswers.isDefined mustBe true

--- a/test/controllers/actions/FakeAuthAction.scala
+++ b/test/controllers/actions/FakeAuthAction.scala
@@ -18,11 +18,12 @@ package controllers.actions
 
 import models.requests.AuthenticatedRequest
 import play.api.mvc.{Request, Result}
+import uk.gov.hmrc.auth.core.Enrolments
 
 import scala.concurrent.Future
 
 object FakeAuthAction extends AuthAction {
   override def invokeBlock[A](request: Request[A], block: (AuthenticatedRequest[A]) => Future[Result]): Future[Result] =
-    block(AuthenticatedRequest(request, "id"))
+    block(AuthenticatedRequest(request, "id", Enrolments(Set())))
 }
 

--- a/test/views/SelectAnOilServiceViewSpec.scala
+++ b/test/views/SelectAnOilServiceViewSpec.scala
@@ -31,9 +31,9 @@ class SelectAnOilServiceViewSpec extends ViewBehaviours {
 
   val serviceInfoContent = HtmlFormat.empty
 
-  def createView = () => selectAnOilService(frontendAppConfig, form)(serviceInfoContent)(fakeRequest, messages)
+  def createView = () => selectAnOilService(frontendAppConfig, form, SelectAnOilService.options.toSeq)(serviceInfoContent)(fakeRequest, messages)
 
-  def createViewUsingForm = (form: Form[_]) => selectAnOilService(frontendAppConfig, form)(serviceInfoContent)(fakeRequest, messages)
+  def createViewUsingForm = (form: Form[_]) => selectAnOilService(frontendAppConfig, form, SelectAnOilService.options.toSeq)(serviceInfoContent)(fakeRequest, messages)
 
   "SelectAnOilService view" must {
     behave like normalPage(createView, messageKeyPrefix)


### PR DESCRIPTION
Pull "allEnrolments" from Auth Context as Confidence level does not matter.
with @callumcodes and @andy1138 