### PR TITLE
BTA | fixed padding on error summary

### DIFF
--- a/app/assets/stylesheets/addtaxesfrontend-app.scss
+++ b/app/assets/stylesheets/addtaxesfrontend-app.scss
@@ -9,8 +9,3 @@
 
 @import 'partials/_shame';
 
-
-
-.heading-medium, .heading-24, h2, .h2-heading {
-    margin-top: .42105em !important;
-}

--- a/app/views/components/error_summary.scala.html
+++ b/app/views/components/error_summary.scala.html
@@ -18,7 +18,7 @@
 @if(errors.nonEmpty) {
     <div class="error-summary error-summary--show" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
 
-        <h2 class="h2-heading" id="error-summary-heading">
+        <h2 class="heading-medium error-summary-heading" id="error-summary-heading">
         @messages("error.summary.title")
         </h2>
 


### PR DESCRIPTION
Removed custom CSS on error summary and updated it to get padding from assets.