### PR TITLE
BTA-624: Adding application loader for base64 decoding

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -53,6 +53,9 @@ play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 play.http.errorHandler = "handlers.ErrorHandler"
 play.http.filters = "filters.Filters"
 
+# An ApplicationLoader that uses Guice to bootstrap the application.
+play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
+
 # Play Modules
 # ~~~~
 # Additional play modules can be added here


### PR DESCRIPTION
Adding applicationLoader https://github.com/hmrc/bootstrap-play-25 which allows us to use Base64 encoding/decoding.