### PR TITLE
BTA-1545: Create feature toggle for new add VAT journey

### DIFF
--- a/app/controllers/actions/FeatureDependantAction.scala
+++ b/app/controllers/actions/FeatureDependantAction.scala
@@ -28,8 +28,8 @@ class FeatureDependantAction @Inject()(config: FeatureConfig) {
 
   def permitFor[R[_]](feature: Feature): ActionFilter[R] = new ActionFilter[R] {
     override protected def filter[A](request: R[A]): Future[Option[Result]] = config.isEnabled(feature) match {
-      case false  => Future.failed(new NotFoundException("The page is not enabled"))
-      case true => Future.successful(None)
+      case false => Future.failed(new NotFoundException("The page is not enabled"))
+      case true  => Future.successful(None)
     }
   }
 

--- a/app/controllers/actions/FeatureDependantAction.scala
+++ b/app/controllers/actions/FeatureDependantAction.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import javax.inject.Inject
+import play.api.mvc.{ActionFilter, Result}
+import playconfig.featuretoggle.{Feature, FeatureConfig}
+import uk.gov.hmrc.http.NotFoundException
+
+import scala.concurrent.Future
+import scala.language.higherKinds
+
+class FeatureDependantAction @Inject()(config: FeatureConfig) {
+
+  def permitFor[R[_]](feature: Feature): ActionFilter[R] = new ActionFilter[R] {
+    override protected def filter[A](request: R[A]): Future[Option[Result]] = config.isEnabled(feature) match {
+      case false  => Future.failed(new NotFoundException("The page is not enabled"))
+      case true => Future.successful(None)
+    }
+  }
+
+}

--- a/app/playconfig/featuretoggle/Feature.scala
+++ b/app/playconfig/featuretoggle/Feature.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package playconfig.featuretoggle
+
+sealed abstract class Feature(val key: String) {
+  require(key.nonEmpty)
+
+  override val toString = s"${Feature.prefix}.$key"
+}
+
+object Feature {
+
+  val prefix = "feature-toggles"
+
+  def allTogglableFeatures: Set[Feature] = Set(
+    NewVatJourney
+  )
+
+  def fromQuery(key: String): Option[Feature] =
+    allTogglableFeatures.collectFirst {
+      case feature if feature.key.toLowerCase == key.toLowerCase => feature
+    }
+
+}
+
+case object NewVatJourney extends Feature("newVatJourney")

--- a/app/playconfig/featuretoggle/FeatureConfig.scala
+++ b/app/playconfig/featuretoggle/FeatureConfig.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package playconfig.featuretoggle
+
+import javax.inject.Inject
+import play.api.Environment
+import uk.gov.hmrc.play.config.ServicesConfig
+
+import scala.util.Try
+
+class FeatureConfig @Inject()(override val runModeConfiguration: play.api.Configuration, environment: Environment)
+    extends ServicesConfig {
+
+  override protected def mode: play.api.Mode.Mode = environment.mode
+
+  def isEnabled(feature: Feature): Boolean =
+    sys.props
+      .get(feature.toString)
+      .flatMap(prop => Try(prop.toBoolean).toOption)
+      .orElse(runModeConfiguration.getBoolean(feature.toString))
+      .getOrElse(false)
+
+}

--- a/app/playconfig/featuretoggle/FeatureToggleSupport.scala
+++ b/app/playconfig/featuretoggle/FeatureToggleSupport.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package playconfig.featuretoggle
+
+trait FeatureToggleSupport {
+
+  def setFeature(feature: Feature, enable: Boolean): Unit =
+    sys.props += (feature.toString -> enable.toString)
+
+  def removeOverride(feature: Feature): Unit =
+    sys.props -= feature.toString
+
+  def enable(feature: Feature): Unit = setFeature(feature, enable = true)
+
+  def disable(feature: Feature): Unit = setFeature(feature, enable = false)
+
+}

--- a/app/testonly/FeatureQueryBinder.scala
+++ b/app/testonly/FeatureQueryBinder.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testonly
+
+import play.api.mvc.QueryStringBindable
+import playconfig.featuretoggle.Feature
+
+import scala.util.Try
+
+object FeatureQueryBinder {
+
+  implicit def queryBinder: QueryStringBindable[List[(Feature, Boolean)]] =
+    new QueryStringBindable[List[(Feature, Boolean)]] {
+      override def bind(
+        key: String,
+        params: Map[String, Seq[String]]): Option[Either[String, List[(Feature, Boolean)]]] = {
+        val requestedMaybeFeatures: List[Option[Feature]] = params.keySet.map(Feature.fromQuery).toList
+        if (requestedMaybeFeatures.exists(_.isEmpty)) {
+          Some(Left("contains unknown feature"))
+        } else {
+          val featuresWithMaybeSettings: List[(Feature, Option[Seq[String]])] =
+            requestedMaybeFeatures.collect {
+              case Some(feature) =>
+                (feature, params.get(params.keySet.find(_.toLowerCase == feature.key.toLowerCase).get))
+            }
+
+          if (featuresWithMaybeSettings.exists(_._2.isEmpty)) {
+            Some(Left("has missing settings"))
+          } else if (featuresWithMaybeSettings.exists(_._2.exists(_.size > 1))) {
+            Some(Left("contains duplicate settings for the same feature"))
+          } else {
+            val featuresWithMaybeSetting: List[(Feature, Option[Boolean])] =
+              featuresWithMaybeSettings.collect {
+                case (feature, Some(maybeBool)) => (feature, Try(maybeBool.head.toBoolean).toOption)
+              }
+
+            if (featuresWithMaybeSetting.exists(_._2.isEmpty)) {
+              Some(Left("contains none boolean settings"))
+            } else {
+              Some(Right(featuresWithMaybeSetting.collect { case (feature, Some(bool)) => (feature, bool) }))
+            }
+          }
+        }
+      }
+
+      override def unbind(key: String, features: List[(Feature, Boolean)]): String =
+        s"""$key=${features.map { case (feature, enable) => s"${feature.key}=$enable" }.mkString("&")}"""
+
+    }
+
+}

--- a/app/testonly/GetFeaturesController.scala
+++ b/app/testonly/GetFeaturesController.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testonly
+
+import javax.inject.Inject
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent}
+import playconfig.featuretoggle.{Feature, FeatureConfig, FeatureToggleSupport}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+
+class GetFeaturesController @Inject()(config: FeatureConfig) extends FrontendController with FeatureToggleSupport {
+
+  def getAllFeatures(): Action[AnyContent] = Action {
+    val features = Feature.allTogglableFeatures
+    Ok(Json.toJson(features.map(feature => Json.obj(feature.key -> config.isEnabled(feature)))))
+  }
+
+}

--- a/app/testonly/ResetFeaturesController.scala
+++ b/app/testonly/ResetFeaturesController.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testonly
+
+import javax.inject.Inject
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent}
+import playconfig.featuretoggle.{Feature, FeatureConfig, FeatureToggleSupport}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+
+class ResetFeaturesController @Inject()(config: FeatureConfig) extends FrontendController with FeatureToggleSupport {
+
+  def reset(): Action[AnyContent] = Action {
+    val features = Feature.allTogglableFeatures
+    features.foreach(removeOverride)
+    Ok(Json.toJson(features.map(feature => Json.obj(feature.key -> config.isEnabled(feature)))))
+  }
+
+}

--- a/app/testonly/SetFeaturesController.scala
+++ b/app/testonly/SetFeaturesController.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testonly
+
+import javax.inject.Inject
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent}
+import playconfig.featuretoggle.{Feature, FeatureConfig, FeatureToggleSupport}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+
+class SetFeaturesController @Inject()(config: FeatureConfig) extends FrontendController with FeatureToggleSupport {
+
+  def set(features: List[(Feature, Boolean)]): Action[AnyContent] = Action {
+    features.foreach { case (feature, setting) => setFeature(feature, setting) }
+    Ok(Json.toJson(features.map { case (feature, _) => Json.obj(feature.key -> config.isEnabled(feature)) }))
+  }
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -181,7 +181,8 @@ feature-toggles {
   employer {
     paye = true
   }
-  mtd-vat-signup = true
+  mtd-vat-signup = true,
+  newVatJourney = true
 }
 
 urls {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -182,7 +182,7 @@ feature-toggles {
     paye = true
   }
   mtd-vat-signup = true,
-  newVatJourney = true
+  newVatJourney = false
 }
 
 urls {

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -11,3 +11,8 @@
 
 # Add all the application routes to the prod.routes file
 ->         /                          prod.Routes
+
+GET        /business-account/add-tax/test-only/set-features          @testonly.SetFeaturesController.set(features: List[(Feature, Boolean)])
+GET        /business-account/add-tax/test-only/get-features          @testonly.GetFeaturesController.getAllFeatures()
+GET        /business-account/add-tax/test-only/reset-features        @testonly.ResetFeaturesController.reset()
+

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -7,7 +7,6 @@ import com.typesafe.sbt.web.Import._
 import net.ground5hark.sbt.concat.Import._
 import com.typesafe.sbt.uglify.Import._
 import com.typesafe.sbt.digest.Import._
-import play.sbt.routes.RoutesKeys
 import com.lucidchart.sbt.scalafmt.ScalafmtCorePlugin.autoImport._
 import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 
@@ -18,7 +17,6 @@ trait MicroService {
   import uk.gov.hmrc.SbtAutoBuildPlugin
   import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
   import uk.gov.hmrc.versioning.SbtGitVersioning
-  import play.sbt.routes.RoutesKeys.routesGenerator
   import play.sbt.routes.RoutesKeys
 
   import TestPhases._
@@ -34,7 +32,12 @@ trait MicroService {
   lazy val microservice = Project(appName, file("."))
     .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory) ++ plugins : _*)
     .settings(playSettings : _*)
-    .settings(RoutesKeys.routesImport ++= Seq("models._", "config.Binders._"))
+    .settings(RoutesKeys.routesImport ++= Seq(
+      "models._",
+      "config.Binders._",
+      "playconfig.featuretoggle.Feature",
+      "testonly.FeatureQueryBinder._"
+    ))
     .settings(
       ScoverageKeys.coverageExcludedFiles := "<empty>;Reverse.*;.*filters.*;.*handlers.*;.*components.*;.*models.*;.*repositories.*;" +
         ".*BuildInfo.*;.*javascript.*;.*FrontendAuditConnector.*;.*Routes.*;.*GuiceInjector;.*DataCacheConnector;" +

--- a/test/controllers/actions/FeatureDependantActionSpec.scala
+++ b/test/controllers/actions/FeatureDependantActionSpec.scala
@@ -30,7 +30,8 @@ import scala.concurrent.Future
 class FeatureDependantActionSpec extends WordSpec with MustMatchers with FeatureToggleSupport with GuiceOneAppPerSuite {
 
   val testFeature: Feature = NewVatJourney
-  val testFeatureDependantAction: FeatureDependantAction = new FeatureDependantAction(app.injector.instanceOf[FeatureConfig])
+  val testFeatureDependantAction: FeatureDependantAction = new FeatureDependantAction(
+    app.injector.instanceOf[FeatureConfig])
   val testAction: ActionFilter[Request] = testFeatureDependantAction.permitFor(testFeature)
 
   val testRequest: Request[AnyContent] = FakeRequest()

--- a/test/controllers/actions/FeatureDependantActionSpec.scala
+++ b/test/controllers/actions/FeatureDependantActionSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.mvc.{ActionFilter, AnyContent, Request, Result}
+import play.api.test.FakeRequest
+import playconfig.featuretoggle._
+import play.api.test.Helpers._
+import play.api.mvc.Results._
+import uk.gov.hmrc.http.NotFoundException
+
+import scala.concurrent.Future
+
+class FeatureDependantActionSpec extends WordSpec with MustMatchers with FeatureToggleSupport with GuiceOneAppPerSuite {
+
+  val testFeature: Feature = NewVatJourney
+  val testFeatureDependantAction: FeatureDependantAction = new FeatureDependantAction(app.injector.instanceOf[FeatureConfig])
+  val testAction: ActionFilter[Request] = testFeatureDependantAction.permitFor(testFeature)
+
+  val testRequest: Request[AnyContent] = FakeRequest()
+  val testResultBody = "testBody"
+  val testBlock: Request[AnyContent] => Future[Result] = _ => Future.successful(Ok(testResultBody))
+
+  "Feature is disabled return not found" in {
+    disable(testFeature)
+
+    val exceptionMessage = intercept[NotFoundException] {
+      val result: Future[Result] = testAction.invokeBlock[AnyContent](testRequest, testBlock)
+      await(result)
+    }
+
+    exceptionMessage.toString must include("The page is not enabled")
+  }
+
+  "Feature is enabled execute the block" in {
+    enable(testFeature)
+
+    val result: Future[Result] = testAction.invokeBlock[AnyContent](testRequest, testBlock)
+
+    status(result) mustBe OK
+    contentAsString(result) mustBe testResultBody
+  }
+
+}

--- a/test/playconfig/featuretoggle/FeatureConfigSpec.scala
+++ b/test/playconfig/featuretoggle/FeatureConfigSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package playconfig.featuretoggle
+
+import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpec}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+
+class FeatureConfigSpec
+    extends WordSpec
+    with MustMatchers
+    with GuiceOneAppPerSuite
+    with FeatureToggleSupport
+    with BeforeAndAfterEach {
+
+  val testToggleValue = true
+
+  override implicit lazy val app: Application = GuiceApplicationBuilder()
+    .configure(s"feature-toggles.${NewVatJourney.key}" -> testToggleValue.toString)
+    .build()
+
+  val config: FeatureConfig = app.injector.instanceOf[FeatureConfig]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    Feature.allTogglableFeatures.foreach(removeOverride)
+  }
+
+  "FeatureConfig.isEnabled" when {
+    "there is a runtime override" should {
+      "return true if the override for the feature is true" in {
+        config.runModeConfiguration.getBoolean(NewVatJourney.toString) mustBe Some(testToggleValue)
+
+        enable(NewVatJourney)
+        config.isEnabled(NewVatJourney) mustBe true
+      }
+      "return false if the override for the feature is false" in {
+        config.runModeConfiguration.getBoolean(NewVatJourney.toString) mustBe Some(testToggleValue)
+
+        disable(NewVatJourney)
+        config.isEnabled(NewVatJourney) mustBe false
+      }
+    }
+    "there is not a runtime override" should {
+      "return true if the config for the feature is true" in {
+        config.runModeConfiguration.getBoolean(NewVatJourney.toString) mustBe Some(testToggleValue)
+
+        config.isEnabled(NewVatJourney) mustBe testToggleValue
+      }
+    }
+  }
+
+}

--- a/test/playconfig/featuretoggle/FeatureObjectSpec.scala
+++ b/test/playconfig/featuretoggle/FeatureObjectSpec.scala
@@ -37,8 +37,7 @@ class FeatureObjectSpec extends WordSpec with MustMatchers with GuiceOneAppPerSu
       def sealedDescendants[Root: TypeTag]: Set[Symbol] = {
         val symbol = typeOf[Root].typeSymbol
         val internal = symbol.asInstanceOf[scala.reflect.internal.Symbols#Symbol]
-        if (internal.isSealed) { internal.sealedDescendants.map(_.asInstanceOf[Symbol]) - symbol }
-        else { Set.empty }
+        if (internal.isSealed) { internal.sealedDescendants.map(_.asInstanceOf[Symbol]) - symbol } else { Set.empty }
       }
 
       val descendants = sealedDescendants[Feature]

--- a/test/playconfig/featuretoggle/FeatureObjectSpec.scala
+++ b/test/playconfig/featuretoggle/FeatureObjectSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package playconfig.featuretoggle
+
+import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+
+class FeatureObjectSpec extends WordSpec with MustMatchers with GuiceOneAppPerSuite {
+
+  "Feature.toString" should {
+    "be in prefix.key format" in {
+      NewVatJourney.toString mustBe "feature-toggles.newVatJourney"
+    }
+  }
+
+  "Feature.allTogglableFeatures" should {
+    "contain all members of Feature" in {
+      import scala.reflect.runtime.universe
+      val mirror = universe.runtimeMirror(getClass.getClassLoader)
+
+      import scala.reflect.runtime.universe._
+
+      def sealedDescendants[Root: TypeTag]: Set[Symbol] = {
+        val symbol = typeOf[Root].typeSymbol
+        val internal = symbol.asInstanceOf[scala.reflect.internal.Symbols#Symbol]
+        if (internal.isSealed) { internal.sealedDescendants.map(_.asInstanceOf[Symbol]) - symbol }
+        else { Set.empty }
+      }
+
+      val descendants = sealedDescendants[Feature]
+
+      val features: Set[Feature] = descendants.collect {
+        case desc if desc.isModuleClass =>
+          val module = mirror.staticModule(desc.asClass.fullName)
+          mirror.reflectModule(module).instance.asInstanceOf[Feature]
+      }
+      Feature.allTogglableFeatures mustBe features
+    }
+
+    "have an associated config value under feature-toggles" in {
+      val config = app.injector.instanceOf[FeatureConfig]
+      Feature.allTogglableFeatures foreach { feature =>
+        withClue(s"feature: $feature\n") {
+          config.runModeConfiguration.getBoolean(feature.toString) mustBe defined
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Copied feature toggle functionality over from BTA and added in action filter which we can use on new vat pages to remove access when journey is toggled off.